### PR TITLE
Changing up to use Credentials in AAP instead of Variables. Also added Windows VM task.

### DIFF
--- a/01-create_vm.yml
+++ b/01-create_vm.yml
@@ -1,22 +1,7 @@
 - name: Create a virtual machine
   hosts: localhost
   tasks:
-    - name: Login to OpenShift
-      redhat.openshift.openshift_auth:
-        host: "{{ openshift_fqdn }}"
-        username: "{{ openshift_user }}"
-        password: "{{ openshift_password }}"
-        validate_certs: false
-      register: openshift_auth_results
-
-    - name: Print authentication rsults
-      ansible.builtin.debug:
-        var: openshift_auth_results
-
     - name: Create VM
       redhat.openshift.k8s:
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
-        host: "{{ openshift_fqdn }}"
-        validate_certs: false
         state: present
         template: templates/rhel-vm.yml

--- a/01-kubevirt_vm.yml
+++ b/01-kubevirt_vm.yml
@@ -4,23 +4,8 @@
     - ./vars/variables.yml
 
   tasks:
-    - name: Login to OpenShift
-      redhat.openshift.openshift_auth:
-        host: "{{ openshift_fqdn }}"
-        username: "{{ openshift_user }}"
-        password: "{{ openshift_password }}"
-        validate_certs: false
-      register: openshift_auth_results
-
-    - name: Print authentication rsults
-      ansible.builtin.debug:
-        var: openshift_auth_results
-
     - name: Create a VirtualMachine with a DataVolume template
       redhat.openshift_virtualization.kubevirt_vm:
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
-        host: "{{ openshift_fqdn }}"
-        validate_certs: false
         state: present
         name: "{{ vm_name }}"
         namespace: "{{ vm_namespace }}"
@@ -88,9 +73,6 @@
 
     - name: Wait for virtual machine IP to be populated
       kubernetes.core.k8s_info:
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
-        host: "{{ openshift_fqdn }}"
-        validate_certs: false
         api_version: kubevirt.io/v1
         kind: VirtualMachineInstance
         name: "{{ vm_name }}"

--- a/02-start_vm.yml
+++ b/02-start_vm.yml
@@ -2,22 +2,7 @@
   hosts: localhost
 
   tasks:
-    - name: Login to OpenShift
-      redhat.openshift.openshift_auth:
-        host: "{{ openshift_fqdn }}"
-        username: "{{ openshift_user }}"
-        password: "{{ openshift_password }}"
-        validate_certs: false
-      register: openshift_auth_results
-
-    - name: Print authentication rsults
-      ansible.builtin.debug:
-        var: openshift_auth_results
-
     - name: Start VM
       redhat.openshift.k8s:
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
-        host: "{{ openshift_fqdn }}"
-        validate_certs: false
         state: present
         template: templates/vm-run.yml

--- a/03-stop_vm.yml
+++ b/03-stop_vm.yml
@@ -2,22 +2,7 @@
   hosts: localhost
 
   tasks:
-    - name: Login to OpenShift
-      redhat.openshift.openshift_auth:
-        host: "{{ openshift_fqdn }}"
-        username: "{{ openshift_user }}"
-        password: "{{ openshift_password }}"
-        validate_certs: false
-      register: openshift_auth_results
-
-    - name: Print authentication rsults
-      ansible.builtin.debug:
-        var: openshift_auth_results
-
     - name: Stop VM
       redhat.openshift.k8s:
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
-        host: "{{ openshift_fqdn }}"
-        validate_certs: false
         state: present
         template: templates/vm-stop.yml

--- a/04-modify_cpu.yml
+++ b/04-modify_cpu.yml
@@ -2,22 +2,7 @@
   hosts: localhost
 
   tasks:
-    - name: Login to OpenShift
-      redhat.openshift.openshift_auth:
-        host: "{{ openshift_fqdn }}"
-        username: "{{ openshift_user }}"
-        password: "{{ openshift_password }}"
-        validate_certs: false
-      register: openshift_auth_results
-
-    - name: Print authentication rsults
-      ansible.builtin.debug:
-        var: openshift_auth_results
-
     - name: Modify VM's CPU and Memory
       redhat.openshift.k8s:
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
-        host: "{{ openshift_fqdn }}"
-        validate_certs: false
         state: present
         template: templates/vm-cpumem.yml

--- a/05-add_disk.yml
+++ b/05-add_disk.yml
@@ -2,30 +2,12 @@
   hosts: localhost
 
   tasks:
-    - name: Login to OpenShift
-      redhat.openshift.openshift_auth:
-        host: "{{ openshift_fqdn }}"
-        username: "{{ openshift_user }}"
-        password: "{{ openshift_password }}"
-        validate_certs: false
-      register: openshift_auth_results
-
-    - name: Print authentication rsults
-      ansible.builtin.debug:
-        var: openshift_auth_results
-
     - name: Create data volume
       redhat.openshift.k8s:
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
-        host: "{{ openshift_fqdn }}"
-        validate_certs: false
         state: present
         template: templates/add-datavolume.yml
 
     - name: Add the created data volume as a new disk into the VM 
       redhat.openshift.k8s:
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
-        host: "{{ openshift_fqdn }}"
-        validate_certs: false
         state: present
         template: templates/add-disk.yml

--- a/06-add_nic.yml
+++ b/06-add_nic.yml
@@ -2,22 +2,7 @@
   hosts: localhost
 
   tasks:
-    - name: Login to OpenShift
-      redhat.openshift.openshift_auth:
-        host: "{{ openshift_fqdn }}"
-        username: "{{ openshift_user }}"
-        password: "{{ openshift_password }}"
-        validate_certs: false
-      register: openshift_auth_results
-
-    - name: Print authentication rsults
-      ansible.builtin.debug:
-        var: openshift_auth_results
-
     - name: Add a new network interface card into the VM 
       redhat.openshift.k8s:
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
-        host: "{{ openshift_fqdn }}"
-        validate_certs: false
         state: present
         template: templates/add-nic.yml

--- a/07-take_snapshot.yml
+++ b/07-take_snapshot.yml
@@ -2,22 +2,7 @@
   hosts: localhost
 
   tasks:
-    - name: Login to OpenShift
-      redhat.openshift.openshift_auth:
-        host: "{{ openshift_fqdn }}"
-        username: "{{ openshift_user }}"
-        password: "{{ openshift_password }}"
-        validate_certs: false
-      register: openshift_auth_results
-
-    - name: Print authentication rsults
-      ansible.builtin.debug:
-        var: openshift_auth_results
-
     - name: Take the snapshot
       redhat.openshift.k8s:
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
-        host: "{{ openshift_fqdn }}"
-        validate_certs: false
         state: present
         template: templates/vm-snapshot.yml

--- a/08-restore_snapshot.yml
+++ b/08-restore_snapshot.yml
@@ -2,22 +2,7 @@
   hosts: localhost
 
   tasks:
-    - name: Login to OpenShift
-      redhat.openshift.openshift_auth:
-        host: "{{ openshift_fqdn }}"
-        username: "{{ openshift_user }}"
-        password: "{{ openshift_password }}"
-        validate_certs: false
-      register: openshift_auth_results
-
-    - name: Print authentication rsults
-      ansible.builtin.debug:
-        var: openshift_auth_results
-
     - name: Restore VM from one existing snapshot
       redhat.openshift.k8s:
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
-        host: "{{ openshift_fqdn }}"
-        validate_certs: false
         state: present
         template: templates/restore-snapshot.yml

--- a/09-delete_vm.yml
+++ b/09-delete_vm.yml
@@ -2,22 +2,7 @@
   hosts: localhost
 
   tasks:
-    - name: Login to OpenShift
-      redhat.openshift.openshift_auth:
-        host: "{{ openshift_fqdn }}"
-        username: "{{ openshift_user }}"
-        password: "{{ openshift_password }}"
-        validate_certs: false
-      register: openshift_auth_results
-
-    - name: Print authentication rsults
-      ansible.builtin.debug:
-        var: openshift_auth_results
-
     - name: Delete VM
       redhat.openshift.k8s:
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
-        host: "{{ openshift_fqdn }}"
-        validate_certs: false
         state: absent
         template: templates/rhel-vm.yml

--- a/15-create_windows_vm.yml
+++ b/15-create_windows_vm.yml
@@ -2,28 +2,16 @@
   hosts: localhost
   vars:
     project_name: aap
+    vm_name: winders
+    vm_iso: install-disk
+    vm_storage_class: windows-vms
+    vm_running: true
+    vm_cpus: 4
+    vm_mem: 8Gi
+    # TODO: MAC ADDRESS/NETWORKS
 
   tasks:
     - name: Create new Windows VM
       redhat.openshift.k8s:
         state: present
         template: templates/windowsvm.j2.yml
-      
-  # redhat.vm:
-  #   namespace: '{{ deploycosmicvm_vm_folder }}'
-  #   name: '{{ deploycosmic_vm_info.name }}'
-  #   state: poweredOff
-  #   guest_id: '{{ guest_id }}' == Windows9Server64Guest
-  #   datastore: storageClass
-  #   hardware: list of stuff i.e. firmware, mb, reservation, same
-  #   cdrom: 'PV'
-  #   disk: list of disks
-  #   networks:
-  #     list of networks
-  #   resource_pool: backup or noclone
-  #   annotations: LOEFP
-  #   tags: vm:loe-fp:
-
-
-# - name: Eject CDROM
-#   # Eject the CDROM

--- a/15-create_windows_vm.yml
+++ b/15-create_windows_vm.yml
@@ -1,7 +1,7 @@
 - name: Create a Windows VM
   hosts: localhost
   vars:
-    project_name: default
+    project_name: aap
 
   tasks:
     - name: Create new Windows VM

--- a/15-create_windows_vm.yml
+++ b/15-create_windows_vm.yml
@@ -1,0 +1,29 @@
+- name: Create a Windows VM
+  hosts: localhost
+  vars:
+    project_name: default
+
+  tasks:
+    - name: Create new Windows VM
+      redhat.openshift.k8s:
+        state: present
+        template: templates/windowsvm.j2.yml
+      
+  # redhat.vm:
+  #   namespace: '{{ deploycosmicvm_vm_folder }}'
+  #   name: '{{ deploycosmic_vm_info.name }}'
+  #   state: poweredOff
+  #   guest_id: '{{ guest_id }}' == Windows9Server64Guest
+  #   datastore: storageClass
+  #   hardware: list of stuff i.e. firmware, mb, reservation, same
+  #   cdrom: 'PV'
+  #   disk: list of disks
+  #   networks:
+  #     list of networks
+  #   resource_pool: backup or noclone
+  #   annotations: LOEFP
+  #   tags: vm:loe-fp:
+
+
+# - name: Eject CDROM
+#   # Eject the CDROM

--- a/16-create_project.yml
+++ b/16-create_project.yml
@@ -1,9 +1,14 @@
 - name: Create a project
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: project.openshift.io/v1
-      metadata:
-        name: aap
-        labels:
-          kubernetes.io/metadata.name: aap
+  hosts: localhost
+
+  tasks:
+    - name: Create Project
+      redhat.openshift.k8s:
+        state: present
+        definition:
+          apiVersion: project.openshift.io/v1
+          kind: Project
+          metadata:
+            name: aap
+            labels:
+              kubernetes.io/metadata.name: aap

--- a/16-create_project.yml
+++ b/16-create_project.yml
@@ -1,5 +1,7 @@
 - name: Create a project
   hosts: localhost
+  vars:
+    project_name: default
 
   tasks:
     - name: Create Project
@@ -9,6 +11,6 @@
           apiVersion: project.openshift.io/v1
           kind: Project
           metadata:
-            name: aap
+            name: "{{ project_name }}"
             labels:
-              kubernetes.io/metadata.name: aap
+              kubernetes.io/metadata.name: "{{ project_name }}"

--- a/16-create_project.yml
+++ b/16-create_project.yml
@@ -1,0 +1,9 @@
+- name: Create a project
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: project.openshift.io/v1
+      metadata:
+        name: aap
+        labels:
+          kubernetes.io/metadata.name: aap

--- a/21-provision_vms.yml
+++ b/21-provision_vms.yml
@@ -17,23 +17,8 @@
     - ./vars/variables.yml
 
   tasks:
-    - name: Login to OpenShift
-      redhat.openshift.openshift_auth:
-        host: "{{ openshift_fqdn }}"
-        username: "{{ openshift_user }}"
-        password: "{{ openshift_password }}"
-        validate_certs: false
-      register: openshift_auth_results
-
-    - name: Print authentication rsults
-      ansible.builtin.debug:
-        var: openshift_auth_results
-
     - name: Create Database VirtualMachine
       redhat.openshift_virtualization.kubevirt_vm:
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
-        host: "{{ openshift_fqdn }}"
-        validate_certs: false
         state: present
         name: "{{ vm_db_name }}"
         namespace: "{{ vm_namespace }}"
@@ -101,9 +86,6 @@
 
     - name: Create JBoss EAP  VirtualMachine
       redhat.openshift_virtualization.kubevirt_vm:
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
-        host: "{{ openshift_fqdn }}"
-        validate_certs: false
         state: present
         name: "{{ vm_app_name }}"
         namespace: "{{ vm_namespace }}"
@@ -171,9 +153,6 @@
 
     - name: Wait for virtual machine IP to be populated
       kubernetes.core.k8s_info:
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
-        host: "{{ openshift_fqdn }}"
-        validate_certs: false
         api_version: kubevirt.io/v1
         kind: VirtualMachineInstance
         name: "{{ vm_app_name }}"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ privileges for now and we'll give it a token which expires in 90 days.
 ```
 oc create sa aap-user -n aap
 oc adm policy add-cluster-role-to-user cluster-admin aap-user -n aap
-oc create token --duration=7776000 aap-user -n aap
+oc create token --duration 7776000s aap-user -n aap
 ```
 
 For more information on creating a service account for AAP, see the official documentation: https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/automation_controller_user_guide/controller-credentials#proc-controller-credential-create-openshift-account.

--- a/README.md
+++ b/README.md
@@ -39,3 +39,27 @@ To create the credential in AAP, you'll need the following information
 For steps on creating a credential for your cluster, see:
 https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/automation_controller_user_guide/controller-credentials#controller-getting-started-create-credential
 
+### Installation Disk
+
+If you're making some Winders VMs or doing a Kickstart build, you'll
+probably want to download an ISO to boot from for the install. In this case, you can create a DataVolume from an ISO like so:
+
+```
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: "install-disk"
+spec:
+  source:
+      http:
+         url: "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img" # S3 or GCS
+         secretRef: "" # Optional
+         certConfigMap: "" # Optional
+  storage:
+    resources:
+      requests:
+        storage: "64Mi"
+```
+
+For more information, see https://github.com/kubevirt/containerized-data-importer/blob/main/doc/datavolumes.md#source
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+= aap4ocp =
+
+This is a collection of ansible tasks used for day 1 and day 2
+administration of OpenShift Virtualization. It's designed to be run
+from AAP - your mileage may vary running from Navigator or the
+commandline.
+
+== Setup ==
+
+You'll need a couple of things for this automation to work.
+
+=== Service Account ===
+
+First, you'll want to have a service account which AAP can use to run
+the automation against your OpenShift cluster. Starting with OpenShift
+4.11, tokens associated with service accounts have a scoped
+duration. We'll create a service account which has cluster admin
+privileges for now and we'll give it a token which expires in 90 days.
+
+```
+oc create sa aap-user -n aap
+oc adm policy add-cluster-role-to-user cluster-admin aap-user -n aap
+oc create token --duration=7776000 aap-user -n aap
+```
+
+For more information on creating a service account for AAP, see the official documentation: https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/automation_controller_user_guide/controller-credentials#proc-controller-credential-create-openshift-account.
+
+The output of the last command should be the token that we'll use to
+create the credential in AAP.
+
+=== Credential in AAP ===
+
+To create the credential in AAP, you'll need the following information
+
+# The API endpoint of the cluster
+# The token associated with the service account
+# Optionally the SSL/CA information.
+
+For steps on creating a credential for your cluster, see:
+https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/automation_controller_user_guide/controller-credentials#controller-getting-started-create-credential
+

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-= aap4ocp =
+# aap4ocp
 
 This is a collection of ansible tasks used for day 1 and day 2
 administration of OpenShift Virtualization. It's designed to be run
 from AAP - your mileage may vary running from Navigator or the
 commandline.
 
-== Setup ==
+## Setup
 
 You'll need a couple of things for this automation to work.
 
-=== Service Account ===
+### Service Account
 
 First, you'll want to have a service account which AAP can use to run
 the automation against your OpenShift cluster. Starting with OpenShift
@@ -28,13 +28,13 @@ For more information on creating a service account for AAP, see the official doc
 The output of the last command should be the token that we'll use to
 create the credential in AAP.
 
-=== Credential in AAP ===
+### Credential in AAP
 
 To create the credential in AAP, you'll need the following information
 
-# The API endpoint of the cluster
-# The token associated with the service account
-# Optionally the SSL/CA information.
+1. The API endpoint of the cluster
+2. The token associated with the service account
+3. Optionally the SSL/CA information.
 
 For steps on creating a credential for your cluster, see:
 https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/automation_controller_user_guide/controller-credentials#controller-getting-started-create-credential

--- a/create_project.yml
+++ b/create_project.yml
@@ -1,28 +1,9 @@
 - name: Hello World Sample
   hosts: localhost
-  vars:
-    openshift_fqdn: https://api.ocp4.example.com:6443
-    openshift_user: test1
-    openshift_password: Redhat!23
-
+  
   tasks:
-    - name: Login to OpenShift
-      redhat.openshift.openshift_auth:
-        host: "{{ openshift_fqdn }}"
-        username: "{{ openshift_user }}"
-        password: "{{ openshift_password }}"
-        validate_certs: false
-      register: openshift_auth_results
-
-    - name: Print authentication rsults
-      ansible.builtin.debug:
-        var: openshift_auth_results
-
     - name: Create namespace
       redhat.openshift.k8s:
-        api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
-        host: "{{ openshift_fqdn }}"
-        validate_certs: false
         state: present
         definition:
           apiVersion: project.openshift.io/v1

--- a/templates/windowsvm.j2.yml
+++ b/templates/windowsvm.j2.yml
@@ -2,42 +2,30 @@ apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   labels:
-    app: win2k19-gold-narwhal-21
+    app: {{ vm_name }}
     vm.kubevirt.io/template: windows2k19-server-medium
     vm.kubevirt.io/template.namespace: openshift
     vm.kubevirt.io/template.revision: '1'
     vm.kubevirt.io/template.version: v0.29.4
-  name: win2k19-gold-narwhal-21
-  namespace: aap
+  name: {{ vm_name }}
+  namespace: {{ project_name }}
 spec:
   dataVolumeTemplates:
     - metadata:
         creationTimestamp: null
-        name: win2k19-gold-narwhal-21-installation-cdrom
+        name: {{ vm_name }}-installation-cdrom
       spec:
         source:
           pvc:
-            name: cosmic-iso
-            namespace: aap
+            name: {{ vm_iso }}
+            namespace: {{ project_name }}
         storage:
           resources:
             requests:
               storage: 5Gi
     - metadata:
         creationTimestamp: null
-        name: win2k19-gold-narwhal-21-datadisk
-      spec:
-        preallocation: false
-        source:
-          blank: {}
-        storage:
-          resources:
-            requests:
-              storage: 100Gi
-          storageClassName: windows-vms
-    - metadata:
-        creationTimestamp: null
-        name: win2k19-gold-narwhal-21
+        name: {{ vm_name }}-rootdisk
       spec:
         preallocation: false
         source:
@@ -46,8 +34,20 @@ spec:
           resources:
             requests:
               storage: 200Gi
-          storageClassName: windows-vms
-  running: true
+          storageClassName: {{ vm_storage_class }}
+    - metadata:
+        creationTimestamp: null
+        name: {{ vm_name }}-datadisk
+      spec:
+        preallocation: false
+        source:
+          blank: {}
+        storage:
+          resources:
+            requests:
+              storage: 100Gi
+          storageClassName: {{ vm_storage_class }}
+  running: {{ vm_running }}
   template:
     metadata:
       annotations:
@@ -56,7 +56,7 @@ spec:
         vm.kubevirt.io/workload: server
       creationTimestamp: null
       labels:
-        kubevirt.io/domain: win2k19-gold-narwhal-21
+        kubevirt.io/domain: {{ vm_name }}
         kubevirt.io/size: medium
     spec:
       architecture: amd64
@@ -73,7 +73,7 @@ spec:
           utc: {}
         cpu:
           cores: 1
-          sockets: 4
+          sockets: {{ vm_cpus }}
           threads: 1
         devices:
           disks:
@@ -87,10 +87,10 @@ spec:
               name: installation-cdrom
             - disk:
                 bus: virtio
-              name: datadisk
+              name: rootdisk
             - disk:
                 bus: virtio
-              name: rootdisk
+              name: datadisk
           inputs:
             - bus: usb
               name: tablet
@@ -126,22 +126,22 @@ spec:
         machine:
           type: pc-q35-rhel9.4.0
         memory:
-          guest: 8Gi
+          guest: {{ vm_mem }}
         resources: {}
       networks:
         - name: default
           pod: {}
       terminationGracePeriodSeconds: 3600
       volumes:
-        - dataVolume:
-            name: win2k19-gold-narwhal-21
-          name: rootdisk
         - containerDisk:
             image: 'registry.redhat.io/container-native-virtualization/virtio-win-rhel9@sha256:93d399b814b0887763bcabc969df767e3501c9ab23278b277bb8f31062ab615c'
           name: windows-drivers-disk
         - dataVolume:
-            name: win2k19-gold-narwhal-21-installation-cdrom
+            name: {{ vm_name }}-installation-cdrom
           name: installation-cdrom
         - dataVolume:
-            name: win2k19-gold-narwhal-21-datadisk
+            name: {{ vm_name }}-rootdisk
+          name: rootdisk
+        - dataVolume:
+            name: {{ vm_name }}-datadisk
           name: datadisk

--- a/templates/windowsvm.j2.yml
+++ b/templates/windowsvm.j2.yml
@@ -8,7 +8,7 @@ metadata:
     vm.kubevirt.io/template.revision: '1'
     vm.kubevirt.io/template.version: v0.29.4
   name: win2k19-gold-narwhal-21
-  namespace: default
+  namespace: aap
 spec:
   dataVolumeTemplates:
     - metadata:
@@ -18,7 +18,7 @@ spec:
         source:
           pvc:
             name: cosmic-iso
-            namespace: default
+            namespace: aap
         storage:
           resources:
             requests:

--- a/templates/windowsvm.j2.yml
+++ b/templates/windowsvm.j2.yml
@@ -96,8 +96,7 @@ spec:
               name: tablet
               type: tablet
           interfaces:
-            - macAddress: '02:73:be:00:00:07'
-              masquerade: {}
+            - masquerade: {}
               model: e1000e
               name: default
         features:

--- a/templates/windowsvm.j2.yml
+++ b/templates/windowsvm.j2.yml
@@ -1,0 +1,147 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  labels:
+    app: win2k19-gold-narwhal-21
+    vm.kubevirt.io/template: windows2k19-server-medium
+    vm.kubevirt.io/template.namespace: openshift
+    vm.kubevirt.io/template.revision: '1'
+    vm.kubevirt.io/template.version: v0.29.4
+  name: win2k19-gold-narwhal-21
+  namespace: default
+spec:
+  dataVolumeTemplates:
+    - metadata:
+        creationTimestamp: null
+        name: win2k19-gold-narwhal-21-installation-cdrom
+      spec:
+        source:
+          pvc:
+            name: cosmic-iso
+            namespace: default
+        storage:
+          resources:
+            requests:
+              storage: 5Gi
+    - metadata:
+        creationTimestamp: null
+        name: win2k19-gold-narwhal-21-datadisk
+      spec:
+        preallocation: false
+        source:
+          blank: {}
+        storage:
+          resources:
+            requests:
+              storage: 100Gi
+          storageClassName: windows-vms
+    - metadata:
+        creationTimestamp: null
+        name: win2k19-gold-narwhal-21
+      spec:
+        preallocation: false
+        source:
+          blank: {}
+        storage:
+          resources:
+            requests:
+              storage: 200Gi
+          storageClassName: windows-vms
+  running: true
+  template:
+    metadata:
+      annotations:
+        vm.kubevirt.io/flavor: medium
+        vm.kubevirt.io/os: windows2k19
+        vm.kubevirt.io/workload: server
+      creationTimestamp: null
+      labels:
+        kubevirt.io/domain: win2k19-gold-narwhal-21
+        kubevirt.io/size: medium
+    spec:
+      architecture: amd64
+      domain:
+        clock:
+          timer:
+            hpet:
+              present: false
+            hyperv: {}
+            pit:
+              tickPolicy: delay
+            rtc:
+              tickPolicy: catchup
+          utc: {}
+        cpu:
+          cores: 1
+          sockets: 4
+          threads: 1
+        devices:
+          disks:
+            - bootOrder: 3
+              cdrom:
+                bus: sata
+              name: windows-drivers-disk
+            - bootOrder: 1
+              cdrom:
+                bus: sata
+              name: installation-cdrom
+            - disk:
+                bus: virtio
+              name: datadisk
+            - disk:
+                bus: virtio
+              name: rootdisk
+          inputs:
+            - bus: usb
+              name: tablet
+              type: tablet
+          interfaces:
+            - macAddress: '02:73:be:00:00:07'
+              masquerade: {}
+              model: e1000e
+              name: default
+        features:
+          acpi: {}
+          apic: {}
+          hyperv:
+            frequencies: {}
+            ipi: {}
+            reenlightenment: {}
+            relaxed: {}
+            reset: {}
+            runtime: {}
+            spinlocks:
+              spinlocks: 8191
+            synic: {}
+            synictimer:
+              direct: {}
+            tlbflush: {}
+            vapic: {}
+            vpindex: {}
+          smm: {}
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: true
+        machine:
+          type: pc-q35-rhel9.4.0
+        memory:
+          guest: 8Gi
+        resources: {}
+      networks:
+        - name: default
+          pod: {}
+      terminationGracePeriodSeconds: 3600
+      volumes:
+        - dataVolume:
+            name: win2k19-gold-narwhal-21
+          name: rootdisk
+        - containerDisk:
+            image: 'registry.redhat.io/container-native-virtualization/virtio-win-rhel9@sha256:93d399b814b0887763bcabc969df767e3501c9ab23278b277bb8f31062ab615c'
+          name: windows-drivers-disk
+        - dataVolume:
+            name: win2k19-gold-narwhal-21-installation-cdrom
+          name: installation-cdrom
+        - dataVolume:
+            name: win2k19-gold-narwhal-21-datadisk
+          name: datadisk


### PR DESCRIPTION
This refactors most of the tasks to use Credentials in AAP instead of relying on variables for the OpenShift API URL and Tokens.

Also added a Create Windows VM task to the list and a Create Project task for smoke testing.